### PR TITLE
Add unary optimization

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6,7 +6,6 @@ use super::bits::{BitRead, BitReader};
 
 pub trait Decode: BitRead + DecodingRead {
     fn decode_rice(&mut self, parameter: usize) -> io::Result<i32>;
-    fn decode_rice_aggressive(&mut self, parameter: usize) -> io::Result<i32>;
 }
 
 pub trait DecodingRead {
@@ -99,15 +98,6 @@ impl<'a, Source: Read + DecodingRead> Decode for BitReader<'a, Source> {
     fn decode_rice(&mut self, parameter: usize) -> io::Result<i32> {
         // unary decoding
         let msb: u32 = self.read_unary()?;
-        let lsb = self.read_u32_bits(parameter)?;
-        let v = ((msb << parameter) | lsb) as i32;
-        // convert to signed (zig-zag decoding)
-        Ok((v >> 1) ^ -(v & 1))
-    }
-
-    fn decode_rice_aggressive(&mut self, parameter: usize) -> io::Result<i32> {
-        // unary decoding
-        let msb: u32 = self.read_unary32()?;
         let lsb = self.read_u32_bits(parameter)?;
         let v = ((msb << parameter) | lsb) as i32;
         // convert to signed (zig-zag decoding)

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6,6 +6,7 @@ use super::bits::{BitRead, BitReader};
 
 pub trait Decode: BitRead + DecodingRead {
     fn decode_rice(&mut self, parameter: usize) -> io::Result<i32>;
+    fn decode_rice_aggressive(&mut self, parameter: usize) -> io::Result<i32>;
 }
 
 pub trait DecodingRead {
@@ -97,10 +98,16 @@ impl<'a, Source: Read + DecodingRead> Decode for BitReader<'a, Source> {
     // Rice Decoding
     fn decode_rice(&mut self, parameter: usize) -> io::Result<i32> {
         // unary decoding
-        let mut msb: u32 = 0;
-        while !self.read_bool()? {
-            msb += 1;
-        }
+        let msb: u32 = self.read_unary()?;
+        let lsb = self.read_u32_bits(parameter)?;
+        let v = ((msb << parameter) | lsb) as i32;
+        // convert to signed (zig-zag decoding)
+        Ok((v >> 1) ^ -(v & 1))
+    }
+
+    fn decode_rice_aggressive(&mut self, parameter: usize) -> io::Result<i32> {
+        // unary decoding
+        let msb: u32 = self.read_unary32()?;
         let lsb = self.read_u32_bits(parameter)?;
         let v = ((msb << parameter) | lsb) as i32;
         // convert to signed (zig-zag decoding)

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,9 @@ pub enum ErrorCode {
 
     FixedLPCCoefficientUnknown,
     QLPPrecisionInvalid,
-    LPCSignalRestoreFailure
+    LPCSignalRestoreFailure,
+
+    FrameBufferUnallocated
 }
 
 #[derive(Debug)]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -342,9 +342,22 @@ impl Subframe {
             // decode
             let offset = vec.len();
             vec.resize(offset + num_samples, 0);
-            let slice = &mut vec[offset..];
-            for sample in slice {
-                *sample = reader.decode_rice(parameter)?;
+
+            if num_samples > 32 {
+                let split = offset + num_samples - 32;
+                let former = &mut vec[offset..split];
+                for sample in former {
+                    *sample = reader.decode_rice_aggressive(parameter)?;
+                }
+                let latter = &mut vec[split..];
+                for sample in latter {
+                    *sample = reader.decode_rice(parameter)?;
+                }
+            } else {
+                let slice = &mut vec[offset..];
+                for sample in slice {
+                    *sample = reader.decode_rice(parameter)?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Adds the following optimization to provide better performance in reading frame blocks

- Pre-allocate buffer
- Use `leading_zeros` to read unary bits

_expecting approx 10% performance boost with this PR_
tested with: 110MB .flac 
4.40sec -> 3.9sec
